### PR TITLE
Correct past event references

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@
 
         <section class="section">
             <h2>Community Calendar</h2>
-            <p>Browse both upcoming and past events from our Luma calendar without leaving this page.</p>
+            <p>Browse upcoming events from our Luma calendar without leaving this page.</p>
             <div class="calendar-embed">
                 <iframe
                     src="https://luma.com/embed/calendar/cal-IB6jRRjjT9BdIMz/events"

--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@
 
         <section class="section">
             <h2>Community Calendar</h2>
-            <p>Browse upcoming events from our Luma calendar without leaving this page.</p>
+            <p>Browse upcoming events from our Luma calendar—we hope to see you soon.</p>
             <div class="calendar-embed">
                 <iframe
                     src="https://luma.com/embed/calendar/cal-IB6jRRjjT9BdIMz/events"


### PR DESCRIPTION
Update Community Calendar blurb to refer only to upcoming events.

---
<a href="https://cursor.com/background-agent?bcId=bc-f74848d7-da15-4c8e-a684-04fb3e2de2aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f74848d7-da15-4c8e-a684-04fb3e2de2aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the Community Calendar paragraph in `index.html` to mention only upcoming events (removes reference to past events).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 178230389cf05139a91ebf0ebb6bde5bad2bc80a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->