### PR TITLE
Add unbranded mode styling and functionality to Code of Conduct and T…

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -300,6 +300,7 @@
 
         @media print {
             body.unbranded .section {
+                break-inside: avoid-page;
                 page-break-inside: avoid;
             }
         }

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -242,12 +242,15 @@
             background-image: none;
         }
 
-        body.unbranded header,
         body.unbranded footer,
         body.unbranded .back-link {
             display: none;
         }
 
+        body.unbranded header {
+            background: #ffffff;
+            box-shadow: none;
+        }
         body.unbranded .container {
             margin-top: 2rem;
             max-width: 800px;

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -225,6 +225,84 @@
             white-space: nowrap;
             border: 0;
         }
+
+        .section a:not(.back-link) {
+            color: var(--accent-color);
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .section a:not(.back-link):hover {
+            text-decoration: underline;
+        }
+
+        /* Unbranded mode - black and white, minimal styling */
+        body.unbranded {
+            background-color: #ffffff;
+            background-image: none;
+        }
+
+        body.unbranded header,
+        body.unbranded footer,
+        body.unbranded .back-link {
+            display: none;
+        }
+
+        body.unbranded .container {
+            margin-top: 2rem;
+            max-width: 800px;
+        }
+
+        body.unbranded .section {
+            background: #ffffff;
+            border: 1px solid #000000;
+            border-radius: 0;
+            box-shadow: none;
+            padding: 2rem;
+            margin-bottom: 2rem;
+        }
+
+        body.unbranded .section::after {
+            display: none;
+        }
+
+        body.unbranded .section:hover {
+            transform: none;
+            box-shadow: none;
+        }
+
+        body.unbranded h2 {
+            color: #000000;
+            background: none;
+            -webkit-background-clip: unset;
+            -webkit-text-fill-color: #000000;
+            background-clip: unset;
+            border-bottom: 2px solid #000000;
+            padding-bottom: 0.5rem;
+            margin-bottom: 1.5rem;
+        }
+
+        body.unbranded h3 {
+            color: #000000;
+            margin-top: 1.5rem;
+        }
+
+        body.unbranded p,
+        body.unbranded li,
+        body.unbranded ul {
+            color: #000000;
+        }
+
+        body.unbranded a {
+            color: #000000 !important;
+            text-decoration: underline !important;
+        }
+
+        @media print {
+            body.unbranded .section {
+                page-break-inside: avoid;
+            }
+        }
     </style>
     <link rel="preload" as="image" href="assets/stockholm-ai-1792w.webp">
 </head>
@@ -309,7 +387,7 @@
 
         <section class="section">
             <h2>Attribution</h2>
-            <p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org" target="_blank" rel="noopener noreferrer" style="color: var(--accent-color); text-decoration: none; font-weight: 600;">Contributor Covenant</a>.</p>
+            <p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org" target="_blank" rel="noopener noreferrer">Contributor Covenant</a>.</p>
             <a href="index.html" class="back-link">← Back to Home</a>
         </section>
     </div>
@@ -319,6 +397,13 @@
     </footer>
     <script>
         document.getElementById('currentYear').textContent = new Date().getFullYear();
+        
+        // Check for unbranded parameter
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.get('unbranded') === 'true' || urlParams.get('unbranded') === '1') {
+            document.body.classList.add('unbranded');
+            document.title = 'Code of Conduct';
+        }
     </script>
 </body>
 </html>

--- a/terms/v1.html
+++ b/terms/v1.html
@@ -253,6 +253,76 @@
         a:hover {
             text-decoration: underline;
         }
+
+        /* Unbranded mode - black and white, minimal styling */
+        body.unbranded {
+            background-color: #ffffff;
+            background-image: none;
+        }
+
+        body.unbranded header,
+        body.unbranded footer,
+        body.unbranded .back-link,
+        body.unbranded .pill {
+            display: none;
+        }
+
+        body.unbranded .container {
+            margin-top: 2rem;
+            max-width: 800px;
+        }
+
+        body.unbranded .section {
+            background: #ffffff;
+            border: 1px solid #000000;
+            border-radius: 0;
+            box-shadow: none;
+            padding: 2rem;
+            margin-bottom: 2rem;
+        }
+
+        body.unbranded .section::after {
+            display: none;
+        }
+
+        body.unbranded .section:hover {
+            transform: none;
+            box-shadow: none;
+        }
+
+        body.unbranded h2 {
+            color: #000000;
+            background: none;
+            -webkit-background-clip: unset;
+            -webkit-text-fill-color: #000000;
+            background-clip: unset;
+            border-bottom: 2px solid #000000;
+            padding-bottom: 0.5rem;
+            margin-bottom: 1.5rem;
+        }
+
+        body.unbranded h3 {
+            color: #000000;
+            margin-top: 1.5rem;
+        }
+
+        body.unbranded p,
+        body.unbranded li,
+        body.unbranded ul,
+        body.unbranded ol {
+            color: #000000;
+        }
+
+        body.unbranded a {
+            color: #000000 !important;
+            text-decoration: underline !important;
+        }
+
+        @media print {
+            body.unbranded .section {
+                page-break-inside: avoid;
+            }
+        }
     </style>
     <link rel="preload" as="image" href="../assets/stockholm-ai-1792w.webp">
 </head>
@@ -362,6 +432,13 @@
     </footer>
     <script>
         document.getElementById('currentYear').textContent = new Date().getFullYear();
+        
+        // Check for unbranded parameter
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.get('unbranded') === 'true' || urlParams.get('unbranded') === '1') {
+            document.body.classList.add('unbranded');
+            document.title = 'Community Event – Terms & Conditions';
+        }
     </script>
 </body>
 </html>

--- a/terms/v1.html
+++ b/terms/v1.html
@@ -320,6 +320,8 @@
 
         @media print {
             body.unbranded .section {
+                break-inside: avoid-page;
+                break-inside: avoid;
                 page-break-inside: avoid;
             }
         }


### PR DESCRIPTION
…erms pages

- Introduced a new unbranded mode with minimal styling for both the Code of Conduct and Terms pages.
- Updated styles to ensure a consistent black and white appearance in unbranded mode.
- Added JavaScript to toggle unbranded mode based on URL parameters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional unbranded display mode for policy pages with minimal black/white styling and print-friendly layout.
> 
> - New `body.unbranded` CSS for `code-of-conduct.html` and `terms/v1.html` (hide header/footer/back-link/pill, remove gradients/shadows, B&W borders/text, simplified headings; print rules to avoid page breaks)
> - JS checks `?unbranded=true|1` to add `unbranded` class and adjust document titles
> - Standardizes link styles in sections; removes inline styling from the attribution link
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 046810f55d9da651341fcf32d32299fca3cb6c0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->